### PR TITLE
fix: stop xcode/ios simulator auto-install on ups and chezmoi apply

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -51,7 +51,7 @@ alias pinentryprogram="$(which pinentry-mac)"
 
 alias brew-update="brew update; brew outdated; brew upgrade; brew cleanup; brew doctor;"
 alias mise-update="mise upgrade --bump; mise reshim;"
-{{ if eq .chezmoi.os "darwin" -}}
+{{ if and (eq .chezmoi.os "darwin") (index . "xcode_auto_update") -}}
 alias ups="brew-update; mise-update; xcode-update"
 {{ else -}}
 alias ups="brew-update; mise-update"

--- a/run_onchange_install-xcode.sh.tmpl
+++ b/run_onchange_install-xcode.sh.tmpl
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-{{ if eq .chezmoi.os "darwin" -}}
+{{ if and (eq .chezmoi.os "darwin") (index . "xcode_auto_update") -}}
 $HOME/bin/xcode-update{{ if index . "work_platform" }} --skip-ios-runtime{{ end }}
 {{ end -}}


### PR DESCRIPTION
## Summary
- Gate `xcode-update` behind an opt-in `xcode_auto_update` chezmoi data flag (defaults off)
- `ups` no longer runs `xcode-update` and `chezmoi apply` no longer auto-triggers Xcode/iOS runtime installs

## Test plan
- [x] `chezmoi diff` reviewed before apply
- [x] `chezmoi apply` applied cleanly, `ups` alias confirmed to exclude `xcode-update`